### PR TITLE
Add missing autocommands for filetype detection

### DIFF
--- a/ftdetect/arcanist.vim
+++ b/ftdetect/arcanist.vim
@@ -22,5 +22,8 @@
 autocmd BufNewFile,BufRead .arc{config,lint,rc,unit} setfiletype json
 
 let s:tmp = !empty($TMPDIR) ? '$TMPDIR' : '/tmp'
-execute 'au BufNewFile,BufRead ' . s:tmp . '/*/new-commit setfiletype arcanistdiff'
+execute 'au BufNewFile,BufRead ' . s:tmp . '/*/arcanist-patch-commit-message setfiletype arcanistdiff'
+execute 'au BufNewFile,BufRead ' . s:tmp . '/*/commit-message setfiletype arcanistdiff'
 execute 'au BufNewFile,BufRead ' . s:tmp . '/*/differential-edit-revision-info setfiletype arcanistdiff'
+execute 'au BufNewFile,BufRead ' . s:tmp . '/*/differential-update-comments setfiletype arcanistdiff'
+execute 'au BufNewFile,BufRead ' . s:tmp . '/*/new-commit setfiletype arcanistdiff'


### PR DESCRIPTION
Found all temporary file names by running the following in the [Arcanist repository][1]:

```bash
grep -r -A4 'newInteractiveEditor' src/ |
	grep -o "setName\S\+'.*')\+" |
	sort -u
```

Note that at least one of these filenames, as of this commit, is run through Arcanist's internationalization function `pht()`, and so this may not work for all locales.

[1]: https://github.com/phacility/arcanist